### PR TITLE
Fix Model State Handling and Replace SciPy Solver with JAX

### DIFF
--- a/lib/datadistillation/frepo.py
+++ b/lib/datadistillation/frepo.py
@@ -13,7 +13,7 @@ import tensorflow as tf
 import jax
 import jax.scipy as sp
 import jax.numpy as jnp
-from scipy.linalg import cho_factor, cho_solve
+from jax.scipy.linalg import cho_factor, cho_solve
 
 import optax
 import flax
@@ -115,7 +115,7 @@ def nfr(x_target, x_proto, y_proto, nn_state, feat_fn, reg=1e-6):
     k_pp = x_proto.dot(x_proto.T)
     k_tp = x_target.dot(x_proto.T)
     k_pp_reg = (k_pp + jnp.abs(reg) * jnp.trace(k_pp) * jnp.eye(k_pp.shape[0]) / k_pp.shape[0])
-    cho_factorized = cho_factor(k_pp_reg)
+    cho_factorized = cho_factor(k_pp_reg, lower=True)
     pred = jnp.dot(k_tp, cho_solve(cho_factorized, y_proto))
     return pred
 

--- a/lib/datadistillation/frepo.py
+++ b/lib/datadistillation/frepo.py
@@ -19,6 +19,7 @@ import flax
 import flax.linen as nn
 from flax.training import checkpoints
 from flax.training import train_state
+from flax.core import freeze, unfreeze
 
 from ..training.metrics import mean_squared_loss, get_metrics, top5_accuracy, soft_cross_entropy_loss, \
     cross_entropy_loss
@@ -89,7 +90,12 @@ def create_proto_state(rng, model, learning_rate_fn, optimizer='lamb'):
     else:
         raise ValueError('Unknown Optimizer {}!'.format(optimizer))
 
-    variables = model.init({'params': rng}).unfreeze()
+    variables = model.init({'params': rng})
+
+    if isinstance(variables, dict):
+        variables = variables
+    else:
+        variables = variables.unfreeze()
 
     state = ProtoState.create(apply_fn=model.apply, tx=tx, params=variables['params'], epoch=0, best_val_acc=0.0)
     return state

--- a/lib/datadistillation/frepo.py
+++ b/lib/datadistillation/frepo.py
@@ -13,6 +13,7 @@ import tensorflow as tf
 import jax
 import jax.scipy as sp
 import jax.numpy as jnp
+from scipy.linalg import cho_factor, cho_solve
 
 import optax
 import flax
@@ -114,7 +115,8 @@ def nfr(x_target, x_proto, y_proto, nn_state, feat_fn, reg=1e-6):
     k_pp = x_proto.dot(x_proto.T)
     k_tp = x_target.dot(x_proto.T)
     k_pp_reg = (k_pp + jnp.abs(reg) * jnp.trace(k_pp) * jnp.eye(k_pp.shape[0]) / k_pp.shape[0])
-    pred = jnp.dot(k_tp, sp.linalg.solve(k_pp_reg, y_proto, sym_pos=True))
+    cho_factorized = cho_factor(k_pp_reg)
+    pred = jnp.dot(k_tp, cho_solve(cho_factorized, y_proto))
     return pred
 
 


### PR DESCRIPTION
This commit introduces two key fixes:

1. **Model State Handling Fix:**

- > Removed the use of `.unfreeze()` on` model.init({'params': rng})`, as `init()` returns a dictionary, not a Flax `FrozenDict`.
- > Ensured that the model variables remain unchanged if they are already a dictionary.

2. **Replaced SciPy `solve()` with JAX Implementation:**

- > The `sp.linalg.solve()` function was causing errors due to an unsupported `sym_pos` argument.
- > Replaced it with JAX’s Cholesky factorization (`cho_factor`) and solver (`cho_solve`).
- > This ensures compatibility with JAX and improves performance by leveraging JIT compilation.
 